### PR TITLE
Add AuthPolicy for Gateway & HTTPRoute

### DIFF
--- a/kserve-setup.sh
+++ b/kserve-setup.sh
@@ -224,11 +224,176 @@ echo "Checking RateLimitPolicy status for 'kserve-override-rlp'..."
 kubectl get ratelimitpolicy kserve-override-rlp -n default -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 echo ""
 
-echo "cURL loop – Ctrl+C when you're done..."
-while true; do 
+echo "Starting a curl loop to test rate limiting (it will run for 20 seconds)..."
+(
+  while true; do 
     curl -s -H "Host: sklearn-v2-iris-predictor-default.example.com" \
          -H "Content-Type: application/json" \
          http://"$GATEWAY_HOST"/v1/models/sklearn-v2-iris:predict -d @/tmp/iris-input.json
     echo ""
+    sleep 3
+  done
+) &
+CURL_LOOP_PID=$!
+sleep 20
+kill $CURL_LOOP_PID
+echo "Rate limiting test loop ended."
+
+echo "Applying AuthPolicy 'kserve-auth' for Gateway..."
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: kserve-auth
+  namespace: kserve
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: kserve-ingress-gateway
+  defaults:
+   when:
+
+     - predicate: "request.path != '/health'"
+   rules:
+    authorization:
+      deny-all:
+        opa:
+          rego: "allow = false"
+    response:
+      unauthorized:
+        headers:
+          "content-type":
+            value: application/json
+        body:
+          value: |
+            {
+              "error": "Forbidden",
+              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
+            }
+EOF
+
+echo "Checking AuthPolicy status for 'kserve-auth'..."
+kubectl get AuthPolicy kserve-auth -n kserve -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+echo ""
+
+echo "Starting a curl loop to test auth fails (it will run for 20 seconds)..."
+(
+  while true; do 
+    curl -s -H "Host: sklearn-v2-iris-predictor-default.example.com" \
+        --write-out '%{http_code}\n' \
+         -H "Content-Type: application/json" \
+         http://"$GATEWAY_HOST"/v1/models/sklearn-v2-iris:predict -d @/tmp/iris-input.json
+    echo ""
+    sleep 3
+  done
+) &
+CURL_LOOP_PID=$!
+sleep 20
+kill $CURL_LOOP_PID
+echo "Auth test loop ended."
+
+
+echo "Setting up API Key auth flow"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bob-key
+  namespace: kuadrant-system
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: toystore
+  annotations:
+    secret.kuadrant.io/user-id: bob
+stringData:
+  api_key: IAMBOB
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alice-key
+  namespace: kuadrant-system
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: toystore
+  annotations:
+    secret.kuadrant.io/user-id: alice
+stringData:
+  api_key: IAMALICE
+type: Opaque
+EOF
+
+echo "Applying AuthPolicy 'kserve-override-auth' for HTTPRoute..."
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: kserve-override-auth
+  namespace: default
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: sklearn-v2-iris-predictor
+  defaults:
+   when:
+     - predicate: "request.path != '/health'"  
+   rules:
+    authentication:
+      "api-key-users":
+        apiKey:
+          selector:
+            matchLabels:
+              app: toystore
+        credentials:
+          authorizationHeader:
+            prefix: APIKEY
+    response:
+      success:
+        filters:
+          "identity":
+            json:
+              properties:
+                "userid":
+                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
+EOF
+
+echo "Checking AuthPolicy status for 'kserve-override-auth'..."
+kubectl get AuthPolicy kserve-override-auth -n default -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+echo ""
+
+echo "Starting a curl loop to test auth fails with wrong API Key (it will run for 20 seconds)..."
+(
+  while true; do 
+    curl -s -H "Host: sklearn-v2-iris-predictor-default.example.com" \
+         --write-out '%{http_code}\n' \
+         --output /dev/null \
+         -H "Content-Type: application/json" \
+         -H 'Authorization: APIKEY IAMALICED' \
+         http://"$GATEWAY_HOST"/v1/models/sklearn-v2-iris:predict -d @/tmp/iris-input.json
     sleep 2
-done
+  done
+) &
+CURL_LOOP_PID=$!
+sleep 20
+kill $CURL_LOOP_PID
+echo "Auth test loop ended."
+
+echo "Starting a curl loop to test auth succeeds with correct API Key (it will run for 20 seconds)..."
+(
+  while true; do 
+    curl -s -H "Host: sklearn-v2-iris-predictor-default.example.com" \
+         --write-out '%{http_code}\n' \
+         --output /dev/null \
+         -H "Content-Type: application/json" \
+         -H 'Authorization: APIKEY IAMALICE' \
+         http://"$GATEWAY_HOST"/v1/models/sklearn-v2-iris:predict -d @/tmp/iris-input.json
+    sleep 2
+  done
+) &
+CURL_LOOP_PID=$!
+sleep 20
+kill $CURL_LOOP_PID
+echo "Auth test loop ended."


### PR DESCRIPTION
Based on https://docs.kuadrant.io/dev/kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect/#secure-and-protect-the-gateway-with-auth-rate-limit-and-dns-policies,
adds API Key auth.

All while loops run for 20 sec now as well.
Visual inspection required during while loop.